### PR TITLE
Update /db permissions recommendation

### DIFF
--- a/data/production_good_practice.xml
+++ b/data/production_good_practice.xml
@@ -109,9 +109,11 @@
                         <varlistentry>
                             <term>/db permissions</term>
                             <listitem>
-                                <warning>The default permissions for /db are 0777, that is to say read-write-update for all!</warning> This should be changed in <emphasis>EVERY</emphasis> production system, to change this to 0774 (rwurwur--) you can run the following XQuery script -  <programlisting language="xquery">declare namespace xmldb = "http://exist-db.org/xquery/xmldb";
-
-xmldb:set-collection-permissions("/db", "admin", "dba", 508)</programlisting>
+                                <para>The default permissions for /db are 0755, which should be sufficient in most cases. In the case you needed to change this, you could do that with (here for 0775):</para>
+                                <programlisting language="xquery">declare namespace xmldb = "http://exist-db.org/xquery/xmldb";
+                                
+                                xmldb:set-collection-permissions("/db", "admin", "dba", 509)</programlisting>
+                                <para>Please, remember the 0775 number in octal is 509, not 775. You can use util:base-to-integer(0775, 8) as argument for convenience.</para>
                             </listitem>
                         </varlistentry>
                     </variablelist>


### PR DESCRIPTION
I have just corrected the /db permissions recommendation. In the current Docs, there is the default permissions are 0777, which is not true. It should be 0755.